### PR TITLE
refactor: Moved service name field from recipes to the instructions arguments

### DIFF
--- a/main.star
+++ b/main.star
@@ -79,14 +79,13 @@ def run(plan, args):
 			first_cl_client = all_cl_client_contexts[0]
 			first_client_beacon_name = first_cl_client.beacon_service_name
 			epoch_recipe = GetHttpRequestRecipe(
-				service_name = first_client_beacon_name,
 				endpoint = "/eth/v1/beacon/states/head/finality_checkpoints",
 				port_id = HTTP_PORT_ID_FOR_FACT,
 				extract = {
 					"finalized_epoch": ".data.finalized.epoch"
 				}
 			)
-			plan.wait(epoch_recipe, "extract.finalized_epoch", "!=", "0", timeout="40m")
+			plan.wait(epoch_recipe, "extract.finalized_epoch", "!=", "0", timeout="40m", service_name = first_client_beacon_name)
 			plan.print("First finalized epoch occurred successfully")
 
 

--- a/src/participant_network/cl/cl_node_health_checker.star
+++ b/src/participant_network/cl/cl_node_health_checker.star
@@ -1,7 +1,6 @@
 def wait_for_healthy(plan, service_name, port_id):
 	recipe = GetHttpRequestRecipe(
-        service_name = service_name,
         endpoint = "/eth/v1/node/health",
         port_id = port_id
     )
-	return plan.wait(recipe, "code", "IN", [200, 206, 503], timeout = "15m")
+	return plan.wait(recipe, "code", "IN", [200, 206, 503], timeout = "15m", service_name = service_name)

--- a/src/participant_network/cl/lighthouse/lighthouse_launcher.star
+++ b/src/participant_network/cl/lighthouse/lighthouse_launcher.star
@@ -118,14 +118,13 @@ def launch(
 
 	# TODO(old) add validator availability using the validator API: https://ethereum.github.io/beacon-APIs/?urls.primaryName=v1#/ValidatorRequiredApi | from eth2-merge-kurtosis-module
 	beacon_node_identity_recipe = GetHttpRequestRecipe(
-		service_name = beacon_node_service_name,
 		endpoint = "/eth/v1/node/identity",
 		port_id = BEACON_HTTP_PORT_ID,
 		extract = {
 			"enr": ".data.enr"
 		}
 	)
-	beacon_node_enr = plan.request(beacon_node_identity_recipe)["extract.enr"]
+	beacon_node_enr = plan.request(beacon_node_identity_recipe, service_name = beacon_node_service_name)["extract.enr"]
 
 	beacon_metrics_port = beacon_service.ports[BEACON_METRICS_PORT_ID]
 	beacon_metrics_url = "{0}:{1}".format(beacon_service.ip_address, beacon_metrics_port.number)

--- a/src/participant_network/cl/lodestar/lodestar_launcher.star
+++ b/src/participant_network/cl/lodestar/lodestar_launcher.star
@@ -105,14 +105,13 @@ def launch(
 	# TODO(old) add validator availability using the validator API: https://ethereum.github.io/beacon-APIs/?urls.primaryName=v1#/ValidatorRequiredApi | from eth2-merge-kurtosis-module
 
 	beacon_node_identity_recipe = GetHttpRequestRecipe(
-		service_name = beacon_node_service_name,
 		endpoint = "/eth/v1/node/identity",
 		port_id = HTTP_PORT_ID,
 		extract = {
 			"enr": ".data.enr"
 		}
 	)
-	beacon_node_enr = plan.request(beacon_node_identity_recipe)["extract.enr"]
+	beacon_node_enr = plan.request(beacon_node_identity_recipe, service_name = beacon_node_service_name)["extract.enr"]
 
 	beacon_metrics_port = beacon_service.ports[METRICS_PORT_ID]
 	beacon_metrics_url = "{0}:{1}".format(beacon_service.ip_address, beacon_metrics_port.number)

--- a/src/participant_network/cl/nimbus/nimbus_launcher.star
+++ b/src/participant_network/cl/nimbus/nimbus_launcher.star
@@ -84,14 +84,13 @@ def launch(
 	cl_node_health_checker.wait_for_healthy(plan, service_name, HTTP_PORT_ID)
 
 	cl_node_identity_recipe = GetHttpRequestRecipe(
-		service_name = service_name,
 		endpoint = "/eth/v1/node/identity",
 		port_id = HTTP_PORT_ID,
 		extract = {
 			"enr": ".data.enr"
 		}
 	)
-	node_enr = plan.request(cl_node_identity_recipe)["extract.enr"]
+	node_enr = plan.request(cl_node_identity_recipe, service_name = service_name)["extract.enr"]
 
 	metrics_port = nimbus_service.ports[METRICS_PORT_ID]
 	metrics_url = "{0}:{1}".format(nimbus_service.ip_address, metrics_port.number)

--- a/src/participant_network/cl/prysm/prysm_launcher.star
+++ b/src/participant_network/cl/prysm/prysm_launcher.star
@@ -130,14 +130,13 @@ def launch(
 
 	# TODO(old) add validator availability using the validator API: https://ethereum.github.io/beacon-APIs/?urls.primaryName=v1#/ValidatorRequiredApi | from eth2-merge-kurtosis-module
 	beacon_node_identity_recipe = GetHttpRequestRecipe(
-		service_name = beacon_node_service_name,
 		endpoint = "/eth/v1/node/identity",
 		port_id = HTTP_PORT_ID,
 		extract = {
 			"enr": ".data.enr"
 		}
 	)
-	beacon_node_enr = plan.request(beacon_node_identity_recipe)["extract.enr"]
+	beacon_node_enr = plan.request(beacon_node_identity_recipe, service_name = beacon_node_service_name)["extract.enr"]
 
 	beacon_metrics_port = beacon_service.ports[BEACON_MONITORING_PORT_ID]
 	beacon_metrics_url = "{0}:{1}".format(beacon_service.ip_address, beacon_metrics_port.number)

--- a/src/participant_network/cl/teku/teku_launcher.star
+++ b/src/participant_network/cl/teku/teku_launcher.star
@@ -91,14 +91,13 @@ def launch(
 	cl_node_health_checker.wait_for_healthy(plan, service_name, HTTP_PORT_ID)
 
 	node_identity_recipe = GetHttpRequestRecipe(
-		service_name = service_name,
 		endpoint = "/eth/v1/node/identity",
 		port_id = HTTP_PORT_ID,
 		extract = {
 			"enr": ".data.enr"
 		}
 	)
-	node_enr = plan.request(node_identity_recipe)["extract.enr"]
+	node_enr = plan.request(node_identity_recipe, service_name = service_name)["extract.enr"]
 
 
 	teku_metrics_port = teku_service.ports[METRICS_PORT_ID]

--- a/src/participant_network/el/el_admin_node_info.star
+++ b/src/participant_network/el/el_admin_node_info.star
@@ -1,7 +1,6 @@
 
 def get_enode_enr_for_node(plan, service_name, port_id):
     recipe = PostHttpRequestRecipe(
-        service_name = service_name,
         endpoint = "",
         body = '{"method":"admin_nodeInfo","params":[],"id":1,"jsonrpc":"2.0"}',
         content_type = "application/json",
@@ -11,12 +10,11 @@ def get_enode_enr_for_node(plan, service_name, port_id):
 			"enr": ".result.enr",
         }
     )
-    response = plan.wait(recipe, "extract.enode", "!=", "", timeout = "15m")
+    response = plan.wait(recipe, "extract.enode", "!=", "", timeout = "15m", service_name = service_name)
     return (response["extract.enode"], response["extract.enr"])
 
 def get_enode_for_node(plan, service_name, port_id):
     recipe = PostHttpRequestRecipe(
-        service_name = service_name,
         endpoint = "",
         body = '{"method":"admin_nodeInfo","params":[],"id":1,"jsonrpc":"2.0"}',
         content_type = "application/json",
@@ -25,5 +23,5 @@ def get_enode_for_node(plan, service_name, port_id):
             "enode": ".result.enode",
         }
     )
-    response = plan.wait(recipe, "extract.enode", "!=", "", timeout = "15m")
+    response = plan.wait(recipe, "extract.enode", "!=", "", timeout = "15m", service_name = service_name)
     return response["extract.enode"]

--- a/src/participant_network/prelaunch_data_generator/cl_genesis/cl_genesis_data_generator.star
+++ b/src/participant_network/prelaunch_data_generator/cl_genesis/cl_genesis_data_generator.star
@@ -83,7 +83,7 @@ def generate_cl_genesis_data(
 		(" && ").join(all_dirpath_creation_commands),
 	]
 
-	dir_creation_cmd_result = plan.exec(ExecRecipe(service_name=launcher_service_name, command=dir_creation_cmd))
+	dir_creation_cmd_result = plan.exec(ExecRecipe(command=dir_creation_cmd), service_name=launcher_service_name)
 	plan.assert(dir_creation_cmd_result["code"], "==", SUCCESSFUL_EXEC_CMD_EXIT_CODE)
 
 
@@ -100,7 +100,7 @@ def generate_cl_genesis_data(
 			filepath_on_generator,
 			OUTPUT_DIRPATH_ON_GENERATOR,
 		]
-		cmd_result = plan.exec(ExecRecipe(service_name=launcher_service_name, command=cmd))
+		cmd_result = plan.exec(ExecRecipe( command=cmd), service_name=launcher_service_name)
 		plan.assert(cmd_result["code"], "==", SUCCESSFUL_EXEC_CMD_EXIT_CODE)
 
 	# Generate files that need dynamic content
@@ -118,7 +118,7 @@ def generate_cl_genesis_data(
 				destFilepath,
 			)
 		]
-		cmd_result = plan.exec(ExecRecipe(service_name=launcher_service_name, command=cmd))
+		cmd_result = plan.exec(ExecRecipe( command=cmd), service_name=launcher_service_name)
 		plan.assert(cmd_result["code"], "==", SUCCESSFUL_EXEC_CMD_EXIT_CODE)
 		
 
@@ -132,7 +132,7 @@ def generate_cl_genesis_data(
 		"--state-output", shared_utils.path_join(OUTPUT_DIRPATH_ON_GENERATOR, GENESIS_STATE_FILENAME)
 	]
 
-	genesis_generation_result = plan.exec(ExecRecipe(service_name=launcher_service_name, command=cl_genesis_generation_cmd))
+	genesis_generation_result = plan.exec(ExecRecipe(command=cl_genesis_generation_cmd), service_name=launcher_service_name)
 	plan.assert(genesis_generation_result["code"], "==", SUCCESSFUL_EXEC_CMD_EXIT_CODE)
 
 	cl_genesis_data_artifact_name = plan.store_service_files(launcher_service_name, OUTPUT_DIRPATH_ON_GENERATOR, name = "cl-genesis-data")

--- a/src/participant_network/prelaunch_data_generator/cl_validator_keystores/cl_validator_keystore_generator.star
+++ b/src/participant_network/prelaunch_data_generator/cl_validator_keystores/cl_validator_keystore_generator.star
@@ -66,7 +66,7 @@ def generate_cl_validator_keystores(
 
 	command_str = " && ".join(all_sub_command_strs)
 
-	command_result = plan.exec(ExecRecipe(service_name=service_name, command=["sh", "-c", command_str]))
+	command_result = plan.exec(ExecRecipe(command=["sh", "-c", command_str]), service_name=service_name)
 	plan.assert(command_result["code"], "==", SUCCESSFUL_EXEC_CMD_EXIT_CODE)
 
 	# Store outputs into files artifacts
@@ -97,7 +97,7 @@ def generate_cl_validator_keystores(
 			PRYSM_PASSWORD_FILEPATH_ON_GENERATOR,
 		),
 	]
-	write_prysm_password_file_cmd_result = plan.exec(ExecRecipe(service_name=service_name, command=write_prysm_password_file_cmd))
+	write_prysm_password_file_cmd_result = plan.exec(ExecRecipe(command=write_prysm_password_file_cmd), service_name=service_name)
 	plan.assert(write_prysm_password_file_cmd_result["code"], "==", SUCCESSFUL_EXEC_CMD_EXIT_CODE)
 
 	prysm_password_artifact_name = plan.store_service_files(service_name, PRYSM_PASSWORD_FILEPATH_ON_GENERATOR, name = "prysm-password")

--- a/src/participant_network/prelaunch_data_generator/el_genesis/el_genesis_data_generator.star
+++ b/src/participant_network/prelaunch_data_generator/el_genesis/el_genesis_data_generator.star
@@ -80,7 +80,7 @@ def generate_el_genesis_data(
 	]
 
 
-	dir_creation_cmd_result = plan.exec(ExecRecipe(service_name=launcher_service_name, command=dir_creation_cmd))
+	dir_creation_cmd_result = plan.exec(ExecRecipe(command=dir_creation_cmd), service_name=launcher_service_name)
 	plan.assert(dir_creation_cmd_result["code"], "==", SUCCESSFUL_EXEC_CMD_EXIT_CODE)
 
 	genesis_config_filepath_on_generator = shared_utils.path_join(CONFIG_DIRPATH_ON_GENERATOR, GENESIS_CONFIG_FILENAME)
@@ -96,7 +96,7 @@ def generate_el_genesis_data(
 			" ".join(cmd)
 		]
 
-		cmd_to_execute_result = plan.exec(ExecRecipe(service_name=launcher_service_name, command=cmd_to_execute))
+		cmd_to_execute_result = plan.exec(ExecRecipe(command=cmd_to_execute), service_name=launcher_service_name)
 		plan.assert(cmd_to_execute_result["code"], "==", SUCCESSFUL_EXEC_CMD_EXIT_CODE)
 
 
@@ -115,7 +115,7 @@ def generate_el_genesis_data(
 		)
 	]
 
-	jwt_secret_generation_cmd_result = plan.exec(ExecRecipe(service_name=launcher_service_name, command=jwt_secret_generation_cmd))
+	jwt_secret_generation_cmd_result = plan.exec(ExecRecipe(command=jwt_secret_generation_cmd), service_name=launcher_service_name)
 	plan.assert(jwt_secret_generation_cmd_result["code"], "==", SUCCESSFUL_EXEC_CMD_EXIT_CODE)
 
 	el_genesis_data_artifact_name = plan.store_service_files(launcher_service_name, OUTPUT_DIRPATH_ON_GENERATOR, name = "el-genesis-data")

--- a/src/testnet_verifier/testnet_verifier.star
+++ b/src/testnet_verifier/testnet_verifier.star
@@ -19,7 +19,7 @@ def run_synchronous_testnet_verification(plan, params, el_client_contexts, cl_cl
 	plan.add_service(SERVICE_NAME, config)
 
 	command = get_cmd(params, el_client_contexts, cl_client_contexts, True)
-	exec_result = plan.exec(ExecRecipe(service_name=SERVICE_NAME, command=command))
+	exec_result = plan.exec(ExecRecipe(command=command), service_name=SERVICE_NAME)
 	plan.assert(exec_result["code"], "==", 0)
 
 


### PR DESCRIPTION
@parithosh I'll merge this PR because you can run the previous version executing the previous version like this `kurtosis run github.com/kurtosis-tech/eth2-package@0fdb74368d5611c062960c71d3d1318cce70382a` 
