### PR TITLE
fix: geth failing after ethash package removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@ Ethereum Package
 This is a [Kurtosis Starlark Package][starlark-docs] that will:
 
 1. Generate EL & CL genesis information using [this genesis generator](https://github.com/skylenet/ethereum-genesis-generator)
-1. Spin up a network of mining Eth1 clients
 1. Spin up a network of Eth2 Beacon/validator clients
 1. Add [a transaction spammer](https://github.com/kurtosis-tech/tx-fuzz) that will repeatedly send transactions to the network
 1. Launch [a consensus monitor](https://github.com/ralexstokes/ethereum_consensus_monitor) instance attached to the network

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,7 +8,6 @@ The overview of this particular package's operation is as follows:
 1. Launch a network of Ethereum participants
     1. Generate execution layer (EL) client config data
     1. Launch EL clients
-    1. Wait for EL clients to start mining, such that all EL clients have a nonzero block number
     1. Generate consensus layer (CL) client config data
     1. Launch CL clients
 1. Launch auxiliary services (Grafana, Forkmon, etc.)
@@ -49,7 +48,7 @@ The participant network is the beating heart at the center of the package. The p
 
 1. Generating EL client config data
 1. Starting the EL clients
-1. Waiting until the EL clients have started mining
+1. Waiting until the EL clients have started producing blocks
 1. Generating CL client config data
 1. Starting the CL clients
 
@@ -61,10 +60,7 @@ All EL clients require both a genesis file and a JWT secret. The exact format of
 The generated output files then get stored in the Kurtosis enclave, ready for use when we start the EL clients. The information about these stored files is tracked in [the `el_genesis_data` struct](https://github.com/kurtosis-tech/eth2-package/blob/main/src/participant_network/prelaunch_data_generator/el_genesis/el_genesis_data.star).
 
 ### Starting EL clients
-Next, we plug the generated genesis data [into EL client "launchers"](https://github.com/kurtosis-tech/eth2-package/tree/main/src/participant_network/el) to start a mining network of EL nodes. The launchers come with a `launch` function that consumes EL genesis data and produces information about the running EL client node. Running EL node information is represented by [an `el_client_context` struct](https://github.com/kurtosis-tech/eth2-package/blob/main/src/participant_network/el/el_client_context.star). Each EL client type has its own launcher (e.g. [Geth](https://github.com/kurtosis-tech/eth2-package/tree/main/src/participant_network/el/geth), [Besu](https://github.com/kurtosis-tech/eth2-package/tree/main/src/participant_network/el/besu)) because each EL client will require different environment variables and flags to be set when launching the client's container.
-
-### Waiting until EL clients have started mining
-Once we have a network of EL nodes started, we block until all EL clients have a block number > 0 to ensure that they are in fact working. After the nodes have started mining, we're ready to move on to adding the CL client network.
+Next, we plug the generated genesis data [into EL client "launchers"](https://github.com/kurtosis-tech/eth2-package/tree/main/src/participant_network/el) to start a network of EL nodes. The launchers come with a `launch` function that consumes EL genesis data and produces information about the running EL client node. Running EL node information is represented by [an `el_client_context` struct](https://github.com/kurtosis-tech/eth2-package/blob/main/src/participant_network/el/el_client_context.star). Each EL client type has its own launcher (e.g. [Geth](https://github.com/kurtosis-tech/eth2-package/tree/main/src/participant_network/el/geth), [Besu](https://github.com/kurtosis-tech/eth2-package/tree/main/src/participant_network/el/besu)) because each EL client will require different environment variables and flags to be set when launching the client's container.
 
 ### Generating CL client data
 CL clients, like EL clients, also have genesis and config files that they need. We use [the same Docker image with tools for generating genesis data][ethereum-genesis-generator] to create the necessary CL files, we provide the genesis generation config using templates in [the `static_files` directory][static-files], and we store the generated output files in the Kurtosis enclave in the same way as the EL client genesis files. Like with EL nodes, CL genesis data information is tracked in [the `cl_client_context` struct](https://github.com/kurtosis-tech/eth2-package/blob/main/src/participant_network/el/el_client_context.star).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -48,7 +48,6 @@ The participant network is the beating heart at the center of the package. The p
 
 1. Generating EL client config data
 1. Starting the EL clients
-1. Waiting until the EL clients have started producing blocks
 1. Generating CL client config data
 1. Starting the CL clients
 

--- a/src/participant_network/el/geth/geth_launcher.star
+++ b/src/participant_network/el/geth/geth_launcher.star
@@ -19,8 +19,6 @@ UDP_DISCOVERY_PORT_ID = "udp-discovery"
 ENGINE_RPC_PORT_ID    = "engine-rpc"
 ENGINE_WS_PORT_ID     = "engineWs"
 
-# TODO(old) Scale this dynamically based on CPUs available and Geth nodes mining
-NUM_MINING_THREADS = 1
 
 GENESIS_DATA_MOUNT_DIRPATH = "/genesis"
 

--- a/src/participant_network/el/nethermind/nethermind_launcher.star
+++ b/src/participant_network/el/nethermind/nethermind_launcher.star
@@ -82,7 +82,6 @@ def get_config(genesis_data, image, existing_el_clients, log_level, extra_params
 	jwt_secret_json_filepath_on_client = shared_utils.path_join(GENESIS_DATA_MOUNT_DIRPATH, genesis_data.jwt_secret_relative_filepath)
 
 	command_args = [
-		"--config=kiln",
 		"--log=" + log_level,
 		"--datadir=" + EXECUTION_DATA_DIRPATH_ON_CLIENT_CONTAINER,
 		"--Init.ChainSpecPath=" + genesis_json_filepath_on_client,
@@ -91,7 +90,6 @@ def get_config(genesis_data, image, existing_el_clients, log_level, extra_params
 		"--JsonRpc.Enabled=true",
 		"--JsonRpc.EnabledModules=net,eth,consensus,subscribe,web3,admin",
 		"--JsonRpc.Host=0.0.0.0",
-		# TODO(old) Set Eth isMining?
 		"--JsonRpc.Port={0}".format(RPC_PORT_NUM),
 		"--JsonRpc.WebSocketsPort={0}".format(WS_PORT_NUM),
 		"--Network.ExternalIp={0}".format(PRIVATE_IP_ADDRESS_PLACEHOLDER),

--- a/src/participant_network/prelaunch_data_generator/prelaunch_data_generator_launcher/prelaunch_data_generator_launcher.star
+++ b/src/participant_network/prelaunch_data_generator/prelaunch_data_generator_launcher/prelaunch_data_generator_launcher.star
@@ -1,4 +1,4 @@
-IMAGE = "ethpandaops/ethereum-genesis-generator:1.0.16"
+IMAGE = "ethpandaops/ethereum-genesis-generator:1.0.17"
 
 SERVICE_NAME_PREFIX = "prelaunch-data-generator-"
 

--- a/src/participant_network/prelaunch_data_generator/prelaunch_data_generator_launcher/prelaunch_data_generator_launcher.star
+++ b/src/participant_network/prelaunch_data_generator/prelaunch_data_generator_launcher/prelaunch_data_generator_launcher.star
@@ -1,4 +1,4 @@
-IMAGE = "ethpandaops/ethereum-genesis-generator:1.0.6"
+IMAGE = "ethpandaops/ethereum-genesis-generator:1.0.16"
 
 SERVICE_NAME_PREFIX = "prelaunch-data-generator-"
 

--- a/src/participant_network/prelaunch_data_generator/prelaunch_data_generator_launcher/prelaunch_data_generator_launcher.star
+++ b/src/participant_network/prelaunch_data_generator/prelaunch_data_generator_launcher/prelaunch_data_generator_launcher.star
@@ -1,4 +1,4 @@
-IMAGE = "ethpandaops/ethereum-genesis-generator:1.0.4"
+IMAGE = "ethpandaops/ethereum-genesis-generator:1.0.6"
 
 SERVICE_ID_PREFIX = "prelaunch-data-generator-"
 


### PR DESCRIPTION
chore: The geth client requires a new field in its genesis.json file, this field specifies that the merge has already happened and would allow the client to start post-merge. The update of the `ethereum-genesis-generator` addresses this. 