### PR TITLE
feat: skip validation for 0 count participants

### DIFF
--- a/src/package_io/parse_input.star
+++ b/src/package_io/parse_input.star
@@ -55,6 +55,9 @@ def parse_input(input_args):
 	total_participant_count = 0
 	# validation of the above defaults
 	for index, participant in enumerate(result["participants"]):
+		if participant["count"] == 0:
+		    continue
+
 		el_client_type = participant["el_client_type"]
 		cl_client_type = participant["cl_client_type"]
 


### PR DESCRIPTION
Useful for when wanting to test certain parameters and not wanting to completely remove incompatible clients from the configuration file.  Example: setting `seconds_per_slot: 2` forces us to remove every nimbus pair