### PR TITLE
fix: pin postgres package

### DIFF
--- a/src/mev_relay/mev_relay_launcher.star
+++ b/src/mev_relay/mev_relay_launcher.star
@@ -1,5 +1,5 @@
 redis_module = import_module("github.com/kurtosis-tech/redis-package/main.star")
-postgres_module = import_module("github.com/kurtosis-tech/postgres-package/main.star@71e945d")  # TODO When Kurtosis has proper version-pinning, use that!!!
+postgres_module = import_module("github.com/kurtosis-tech/postgres-package/main.star@83d05e639096fe58109b8574eb74ecd27688fc95")  # TODO When Kurtosis has proper version-pinning, use that!!!
 
 DUMMY_SECRET_KEY = "0x607a11b45a7219cc61a3d9c5fd08c7eebd602a6a19a977f8d3771d5711a550f2"
 DUMMY_PUB_KEY = "0xa55c1285d84ba83a5ad26420cd5ad3091e49c55a813eee651cd467db38a8c8e63192f47955e9376f6b42f6d190571cb5"

--- a/src/mev_relay/mev_relay_launcher.star
+++ b/src/mev_relay/mev_relay_launcher.star
@@ -1,5 +1,5 @@
 redis_module = import_module("github.com/kurtosis-tech/redis-package/main.star")
-postgres_module = import_module("github.com/kurtosis-tech/postgres-package/main.star")
+postgres_module = import_module("github.com/kurtosis-tech/postgres-package/main.star@71e945d")  # TODO When Kurtosis has proper version-pinning, use that!!!
 
 DUMMY_SECRET_KEY = "0x607a11b45a7219cc61a3d9c5fd08c7eebd602a6a19a977f8d3771d5711a550f2"
 DUMMY_PUB_KEY = "0xa55c1285d84ba83a5ad26420cd5ad3091e49c55a813eee651cd467db38a8c8e63192f47955e9376f6b42f6d190571cb5"


### PR DESCRIPTION
The Postgres package always pulls the latest from `master`, meaning any breaking changes to it will immediately break this package. This pins the Postgres version in preparation for a breaking change