### PR TITLE
feat: Make args optional

### DIFF
--- a/main.star
+++ b/main.star
@@ -31,7 +31,7 @@ MOCK_MEV_TYPE = "mock"
 FULL_MEV_TYPE = "full"
 PATH_TO_PARSED_BEACON_STATE = "/genesis/output/parsedBeaconState.json"
 
-def run(plan, args):
+def run(plan, args = {}):
 	args_with_right_defaults, args_with_defaults_dict = parse_input.parse_input(plan, args)
 
 	num_participants = len(args_with_right_defaults.participants)


### PR DESCRIPTION
Makes the `args` argument to `main.star#run` optional, so that this is even easier to import in other code chunks